### PR TITLE
[TASK] Change to flow package type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "typo3/party",
-	"type": "typo3-flow-framework",
+	"type": "typo3-flow-package",
 	"description": "A PHP implementation of the OASIS Customer Information Quality (CIQ) XML Standard.",
 	"license": "LGPL-3.0+",
 	"require": {


### PR DESCRIPTION
Makes the party package a "typo3-flow-package" that is installed
into the "Packages/Application" folder by default.
