### PR TITLE
BUGFIX: Migrations for MySQL and PostgreSQL pick up accounts without party

### DIFF
--- a/Migrations/Mysql/Version20150206113911.php
+++ b/Migrations/Mysql/Version20150206113911.php
@@ -23,7 +23,7 @@ class Version20150206113911 extends AbstractMigration {
 		$this->addSql("ALTER TABLE typo3_party_domain_model_abstractparty_accounts_join ADD CONSTRAINT FK_1EEEBC2F58842EFC FOREIGN KEY (flow_security_account) REFERENCES typo3_flow_security_account (persistence_object_identifier)");
 
 		if ($this->partyColumnInFlowSecurityAccountExists()) {
-			$this->addSql("INSERT INTO typo3_party_domain_model_abstractparty_accounts_join (flow_security_account, party_abstractparty) SELECT persistence_object_identifier, party FROM typo3_flow_security_account");
+			$this->addSql("INSERT INTO typo3_party_domain_model_abstractparty_accounts_join (flow_security_account, party_abstractparty) SELECT persistence_object_identifier, party FROM typo3_flow_security_account WHERE party IS NOT NULL");
 		}
 	}
 

--- a/Migrations/Postgresql/Version20150216124451.php
+++ b/Migrations/Postgresql/Version20150216124451.php
@@ -21,7 +21,7 @@ class Version20150216124451 extends AbstractMigration {
 		$this->addSql("ALTER TABLE typo3_party_domain_model_abstractparty_accounts_join ADD CONSTRAINT FK_1EEEBC2F58842EFC FOREIGN KEY (flow_security_account) REFERENCES typo3_flow_security_account (persistence_object_identifier) NOT DEFERRABLE INITIALLY IMMEDIATE");
 
 		if ($this->partyColumnInFlowSecurityAccountExists()) {
-			$this->addSql("INSERT INTO typo3_party_domain_model_abstractparty_accounts_join (flow_security_account, party_abstractparty) SELECT persistence_object_identifier, party FROM typo3_flow_security_account");
+			$this->addSql("INSERT INTO typo3_party_domain_model_abstractparty_accounts_join (flow_security_account, party_abstractparty) SELECT persistence_object_identifier, party FROM typo3_flow_security_account WHERE party IS NOT NULL");
 		}
 	}
 


### PR DESCRIPTION
This fixes the migrations so only rows with a party set will be inserted into the join table
