### PR TITLE
BUGFIX: Avoid cross influence in MySQL migrations

### DIFF
--- a/Migrations/Mysql/Version20150309181636.php
+++ b/Migrations/Mysql/Version20150309181636.php
@@ -17,10 +17,15 @@ class Version20150309181636 extends AbstractMigration {
 		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
 		$this->addSql("ALTER TABLE typo3_party_domain_model_person_electronicaddresses_join DROP FOREIGN KEY typo3_party_domain_model_person_electronicaddresses_join_ibfk_2");
-		$this->addSql("DROP INDEX idx_759cc08f72aaaa2f ON typo3_party_domain_model_person_electronicaddresses_join");
-		$this->addSql("CREATE INDEX IDX_BE7D49F772AAAA2F ON typo3_party_domain_model_person_electronicaddresses_join (party_person)");
-		$this->addSql("DROP INDEX idx_759cc08fb06bd60d ON typo3_party_domain_model_person_electronicaddresses_join");
-		$this->addSql("CREATE INDEX IDX_BE7D49F7B06BD60D ON typo3_party_domain_model_person_electronicaddresses_join (party_electronicaddress)");
+		$indexes = $this->sm->listTableIndexes('typo3_party_domain_model_person_electronicaddresses_join');
+		if (array_key_exists('idx_759cc08f72aaaa2f', $indexes)) {
+			$this->addSql("DROP INDEX idx_759cc08f72aaaa2f ON typo3_party_domain_model_person_electronicaddresses_join");
+			$this->addSql("CREATE INDEX IDX_BE7D49F772AAAA2F ON typo3_party_domain_model_person_electronicaddresses_join (party_person)");
+		}
+		if (array_key_exists('idx_759cc08fb06bd60d', $indexes)) {
+			$this->addSql("DROP INDEX idx_759cc08fb06bd60d ON typo3_party_domain_model_person_electronicaddresses_join");
+			$this->addSql("CREATE INDEX IDX_BE7D49F7B06BD60D ON typo3_party_domain_model_person_electronicaddresses_join (party_electronicaddress)");
+		}
 		$this->addSql("ALTER TABLE typo3_party_domain_model_person_electronicaddresses_join ADD CONSTRAINT typo3_party_domain_model_person_electronicaddresses_join_ibfk_2 FOREIGN KEY (party_electronicaddress) REFERENCES typo3_party_domain_model_electronicaddress (persistence_object_identifier)");
 	}
 


### PR DESCRIPTION
There have been cleanup migrations added in the past that interact in
breaking ways with each other. This changes the index creation to only
happen if needed.
