### PR TITLE
BUGFIX: Skype ID can contain underscore and colon

### DIFF
--- a/Classes/TYPO3/Party/Validation/Validator/SkypeAddressValidator.php
+++ b/Classes/TYPO3/Party/Validation/Validator/SkypeAddressValidator.php
@@ -1,6 +1,5 @@
 <?php
 namespace TYPO3\Party\Validation\Validator;
-
 /*                                                                        *
  * This script belongs to the TYPO3 Flow package "Party".                 *
  *                                                                        *
@@ -10,9 +9,7 @@ namespace TYPO3\Party\Validation\Validator;
  *                                                                        *
  * The TYPO3 project - inspiring people to share!                         *
  *                                                                        */
-
 use TYPO3\Flow\Annotations as Flow;
-
 /**
  * Validator for Skype addresses.
  *
@@ -20,13 +17,19 @@ use TYPO3\Flow\Annotations as Flow;
  * @Flow\Scope("singleton")
  */
 class SkypeAddressValidator extends \TYPO3\Flow\Validation\Validator\AbstractValidator {
-
 	/**
 	 * Checks if the given value is a valid Skype name.
 	 *
 	 * The Skype website says: "It must be between 6-32 characters, start with
 	 * a letter and contain only letters and numbers (no spaces or special
 	 * characters)."
+	 * 
+	 * Nevertheless dash and underscore are allowed as special characters.
+	 * Furthermore, account names can contain a colon if they were auto-created
+	 * trough a connected Microsoft or Facebook profile. In this case, the syntax
+	 * is as follows:
+	 * - live:john.due
+	 * - Facebook:john.doe
 	 *
 	 * We added period and minus as additional characters because they are
 	 * suggested by Skype during registration.
@@ -36,7 +39,7 @@ class SkypeAddressValidator extends \TYPO3\Flow\Validation\Validator\AbstractVal
 	 * @api
 	 */
 	protected function isValid($value) {
-		if (!is_string($value) || preg_match('/^[a-z][a-z0-9\.-]{5,31}$/Dix', $value) !== 1) {
+		if (!is_string($value) || preg_match('/^[a-z][a-z0-9\._:-]{5,31}$/Dix', $value) !== 1) {
 			$this->addError(
 				'Please specify a valid Skype address (It must be between 6-32 characters and start with a letter).',
 				1343235498


### PR DESCRIPTION
While the SkypeAddressValidator correctly validates for the allowed syntax stated on the Skype website, Skype also accepts underscores as special character in the name and creates accounts with a colon in the name through 3rd party accounts.

Accounts created through a Microsoft account have a "live:" prefix, accounts created through Facebook a "Facebook:" prefix.

Therefore the SkypeAddressValidator must allow using these characters.
