### PR TITLE
BUGFIX: Prevent stale object references in party cache, pt II

### DIFF
--- a/Classes/TYPO3/Party/Domain/Model/AbstractParty.php
+++ b/Classes/TYPO3/Party/Domain/Model/AbstractParty.php
@@ -15,7 +15,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Flow\Annotations as Flow;
-use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Security\Account;
 
 /**

--- a/Classes/TYPO3/Party/Domain/Service/PartyService.php
+++ b/Classes/TYPO3/Party/Domain/Service/PartyService.php
@@ -58,7 +58,8 @@ class PartyService {
 		$party->addAccount($account);
 
 		$accountIdentifier = $this->persistenceManager->getIdentifierByObject($account);
-		$this->accountsInPartyRuntimeCache[$accountIdentifier] = $party;
+		// We need to prevent stale object references and therefore only cache the identifier.
+		$this->accountsInPartyRuntimeCache[$accountIdentifier] = $this->persistenceManager->getIdentifierByObject($party);
 	}
 
 	/**

--- a/Tests/Unit/Domain/Service/PartyServiceTest.php
+++ b/Tests/Unit/Domain/Service/PartyServiceTest.php
@@ -71,7 +71,12 @@ class PartyServiceTest extends UnitTestCase {
 	 * @test
 	 */
 	public function assignAccountToPartyCachesAssignedParty() {
-		$this->mockPersistenceManager->expects($this->any())->method('getIdentifierByObject')->will($this->returnValue('723e3913-f803-42c8-a44c-fd7115f555c3'));
+		$accountIdentifier = '723e3913-f803-42c8-a44c-fd7115f555c3';
+		$partyIdentifier = 'f8033913-723e-42c8-a44c-fd7115f555c3';
+		$this->mockPersistenceManager->expects($this->at(1))->method('getIdentifierByObject')->with($this->party)->will($this->returnValue($partyIdentifier));
+		$this->mockPersistenceManager->expects($this->at(2))->method('getIdentifierByObject')->with($this->account)->will($this->returnValue($accountIdentifier));
+		$this->mockPersistenceManager->expects($this->any())->method('getObjectByIdentifier')->with($partyIdentifier)->will($this->returnValue($this->party));
+		$this->mockPartyRepository->expects($this->any())->method('findOneHavingAccount')->with($this->account)->will($this->returnValue($this->party));
 
 		$this->partyService->assignAccountToParty($this->account, $this->party);
 
@@ -84,9 +89,12 @@ class PartyServiceTest extends UnitTestCase {
 	 * @test
 	 */
 	public function getAssignedPartyOfAccountCachesParty() {
-		$this->mockPersistenceManager->expects($this->any())->method('getIdentifierByObject')->will($this->returnValue('723e3913-f803-42c8-a44c-fd7115f555c3'));
-
-		$this->mockPartyRepository->expects($this->once())->method('findOneHavingAccount')->with($this->account)->will($this->returnValue($this->party));
+		$accountIdentifier = '723e3913-f803-42c8-a44c-fd7115f555c3';
+		$partyIdentifier = 'f8033913-723e-42c8-a44c-fd7115f555c3';
+		$this->mockPersistenceManager->expects($this->at(1))->method('getIdentifierByObject')->with($this->party)->will($this->returnValue($partyIdentifier));
+		$this->mockPersistenceManager->expects($this->at(2))->method('getIdentifierByObject')->with($this->account)->will($this->returnValue($accountIdentifier));
+		$this->mockPersistenceManager->expects($this->any())->method('getObjectByIdentifier')->with($partyIdentifier)->will($this->returnValue($this->party));
+		$this->mockPartyRepository->expects($this->any())->method('findOneHavingAccount')->with($this->account)->will($this->returnValue($this->party));
 
 		$this->party->addAccount($this->account);
 


### PR DESCRIPTION
A follow-up to an earlier bugfix. This adjusts tests as needed and
fixes setting the cache in assignAccountToParty().