### PR TITLE
TASK: Fix warning in PersonName and PersonNameTest

### DIFF
--- a/Classes/Domain/Model/PersonName.php
+++ b/Classes/Domain/Model/PersonName.php
@@ -68,14 +68,14 @@ class PersonName
      * @param string $alias an alias or nickname
      * @var string
      */
-    public function __construct(string $title = '', string $firstName = '', string $middleName = '', string $lastName = '', string $otherName = '', string $alias = '')
+    public function __construct($title = '', $firstName = '', $middleName = '', $lastName = '', $otherName = '', $alias = '')
     {
-        $this->title = $title;
-        $this->firstName = $firstName;
-        $this->middleName = $middleName;
-        $this->lastName = $lastName;
-        $this->otherName = $otherName;
-        $this->alias = $alias;
+        $this->title = (string)$title;
+        $this->firstName = (string)$firstName;
+        $this->middleName = (string)$middleName;
+        $this->lastName = (string)$lastName;
+        $this->otherName = (string)$otherName;
+        $this->alias = (string)$alias;
 
         $this->generateFullName();
     }
@@ -110,7 +110,7 @@ class PersonName
      */
     public function setFirstName($firstName)
     {
-        $this->firstName = $firstName;
+        $this->firstName = (string)$firstName;
         $this->generateFullName();
     }
 
@@ -122,7 +122,7 @@ class PersonName
      */
     public function setMiddleName($middleName)
     {
-        $this->middleName = $middleName;
+        $this->middleName = (string)$middleName;
         $this->generateFullName();
     }
 
@@ -134,7 +134,7 @@ class PersonName
      */
     public function setLastName($lastName)
     {
-        $this->lastName = $lastName;
+        $this->lastName = (string)$lastName;
         $this->generateFullName();
     }
 
@@ -146,7 +146,7 @@ class PersonName
      */
     public function setTitle($title)
     {
-        $this->title = $title;
+        $this->title = (string)$title;
         $this->generateFullName();
     }
 
@@ -158,7 +158,7 @@ class PersonName
      */
     public function setOtherName($otherName)
     {
-        $this->otherName = $otherName;
+        $this->otherName = (string)$otherName;
         $this->generateFullName();
     }
 
@@ -170,7 +170,7 @@ class PersonName
      */
     public function setAlias($alias)
     {
-        $this->alias = $alias;
+        $this->alias = (string)$alias;
     }
 
     /**

--- a/Classes/Domain/Model/PersonName.php
+++ b/Classes/Domain/Model/PersonName.php
@@ -68,7 +68,7 @@ class PersonName
      * @param string $alias an alias or nickname
      * @var string
      */
-    public function __construct($title = '', $firstName = '', $middleName = '', $lastName = '', $otherName = '', $alias = '')
+    public function __construct(string $title = '', string $firstName = '', string $middleName = '', string $lastName = '', string $otherName = '', string $alias = '')
     {
         $this->title = $title;
         $this->firstName = $firstName;

--- a/Tests/Unit/Domain/Model/PersonNameTest.php
+++ b/Tests/Unit/Domain/Model/PersonNameTest.php
@@ -25,7 +25,7 @@ class PersonNameTest extends UnitTestCase
      */
     public function fullNameIsBuiltUpRightFromNameParts()
     {
-        $personName = new PersonName(null, 'Sebastian', null, 'Michaelsen', '(born Gebhard)');
+        $personName = new PersonName('', 'Sebastian', '', 'Michaelsen', '(born Gebhard)');
         Assert::assertEquals('Sebastian Michaelsen (born Gebhard)', $personName->getFullName());
     }
 }


### PR DESCRIPTION
Fixes `trim(): Passing null to parameter #1 ($string) of type string is deprecated`