### PR TITLE
TASK: Fix migrations for MariaDB 12.x

### DIFF
--- a/Migrations/Mysql/Version20110923125536.php
+++ b/Migrations/Mysql/Version20110923125536.php
@@ -16,10 +16,19 @@ class Version20110923125536 extends AbstractMigration {
 	public function up(Schema $schema): void  {
 		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
-		$this->addSql("ALTER TABLE typo3_party_domain_model_person DROP FOREIGN KEY typo3_party_domain_model_person_ibfk_1");
-		$this->addSql("ALTER TABLE typo3_party_domain_model_person DROP FOREIGN KEY typo3_party_domain_model_person_ibfk_2");
-		$this->addSql("DROP INDEX UNIQ_72AAAA2F987E5DAB ON typo3_party_domain_model_person");
-		$this->addSql("DROP INDEX IDX_72AAAA2FB06BD60D ON typo3_party_domain_model_person");
+        foreach ($this->sm->listTableForeignKeys('typo3_party_domain_model_person') as $foreignKey) {
+            if (in_array('party_personname', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+            || in_array('party_electronicaddress', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_party_domain_model_person DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+        $indexes = $this->sm->listTableIndexes('typo3_party_domain_model_person');
+        if (array_key_exists('uniq_72aaaa2f987e5dab', $indexes)) {
+            $this->addSql("DROP INDEX UNIQ_72AAAA2F987E5DAB ON typo3_party_domain_model_person");
+        }
+        if (array_key_exists('idx_72aaaa2fb06bd60d', $indexes)) {
+            $this->addSql("DROP INDEX IDX_72AAAA2FB06BD60D ON typo3_party_domain_model_person");
+        }
 		$this->addSql("ALTER TABLE typo3_party_domain_model_person CHANGE party_personname name VARCHAR(40) DEFAULT NULL, CHANGE party_electronicaddress primaryelectronicaddress VARCHAR(40) DEFAULT NULL");
 		$this->addSql("ALTER TABLE typo3_party_domain_model_person ADD CONSTRAINT typo3_party_domain_model_person_ibfk_1 FOREIGN KEY (name) REFERENCES typo3_party_domain_model_personname(flow3_persistence_identifier)");
 		$this->addSql("ALTER TABLE typo3_party_domain_model_person ADD CONSTRAINT typo3_party_domain_model_person_ibfk_2 FOREIGN KEY (primaryelectronicaddress) REFERENCES typo3_party_domain_model_electronicaddress(flow3_persistence_identifier)");
@@ -34,8 +43,12 @@ class Version20110923125536 extends AbstractMigration {
 	public function down(Schema $schema): void  {
 		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
-		$this->addSql("ALTER TABLE typo3_party_domain_model_person DROP FOREIGN KEY typo3_party_domain_model_person_ibfk_1");
-		$this->addSql("ALTER TABLE typo3_party_domain_model_person DROP FOREIGN KEY typo3_party_domain_model_person_ibfk_2");
+        foreach ($this->sm->listTableForeignKeys('typo3_party_domain_model_person') as $foreignKey) {
+            if (in_array('name', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+                || in_array('primaryelectronicaddress', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_party_domain_model_person DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
 		$this->addSql("DROP INDEX UNIQ_C60479E15E237E06 ON typo3_party_domain_model_person");
 		$this->addSql("DROP INDEX IDX_C60479E1A7CECF13 ON typo3_party_domain_model_person");
 		$this->addSql("ALTER TABLE typo3_party_domain_model_person CHANGE name party_personname VARCHAR(40) DEFAULT NULL, CHANGE primaryelectronicaddress party_electronicaddress VARCHAR(40) DEFAULT NULL");

--- a/Migrations/Mysql/Version20150309181636.php
+++ b/Migrations/Mysql/Version20150309181636.php
@@ -16,7 +16,11 @@ class Version20150309181636 extends AbstractMigration {
 	public function up(Schema $schema): void  {
 		$this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
-		$this->addSql("ALTER TABLE typo3_party_domain_model_person_electronicaddresses_join DROP FOREIGN KEY typo3_party_domain_model_person_electronicaddresses_join_ibfk_2");
+        foreach ($this->sm->listTableForeignKeys('typo3_party_domain_model_person_electronicaddresses_join') as $foreignKey) {
+            if (in_array('party_electronicaddress', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_party_domain_model_person_electronicaddresses_join DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
 		$indexes = $this->sm->listTableIndexes('typo3_party_domain_model_person_electronicaddresses_join');
 		if (array_key_exists('idx_759cc08f72aaaa2f', $indexes)) {
 			$this->addSql("DROP INDEX idx_759cc08f72aaaa2f ON typo3_party_domain_model_person_electronicaddresses_join");

--- a/Migrations/Mysql/Version20170110130325.php
+++ b/Migrations/Mysql/Version20170110130325.php
@@ -41,16 +41,28 @@ class Version20170110130325 extends AbstractMigration
             $this->addSql('CREATE UNIQUE INDEX UNIQ_E4E61AB058842EFC ON neos_party_domain_model_abstractparty_accounts_join (flow_security_account)');
             $this->addSql('ALTER TABLE neos_party_domain_model_abstractparty_accounts_join ADD CONSTRAINT FK_1EEEBC2F38110E12 FOREIGN KEY (party_abstractparty) REFERENCES neos_party_domain_model_abstractparty (persistence_object_identifier)');
             $this->addSql('ALTER TABLE neos_party_domain_model_abstractparty_accounts_join ADD CONSTRAINT FK_1EEEBC2F58842EFC FOREIGN KEY (flow_security_account) REFERENCES neos_flow_security_account (persistence_object_identifier) ON DELETE CASCADE');
-            $this->addSql('ALTER TABLE neos_party_domain_model_person DROP FOREIGN KEY neos_party_domain_model_person_ibfk_1');
-            $this->addSql('ALTER TABLE neos_party_domain_model_person DROP FOREIGN KEY neos_party_domain_model_person_ibfk_2');
+
+            foreach ($this->sm->listTableForeignKeys('neos_party_domain_model_person') as $foreignKey) {
+                if (in_array('name', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+                    || in_array('primaryelectronicaddress', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+                ) {
+                    $this->addSql("ALTER TABLE neos_party_domain_model_person DROP FOREIGN KEY " . $foreignKey->getName());
+                }
+            }
             $this->addSql('DROP INDEX uniq_c60479e15e237e06 ON neos_party_domain_model_person');
             $this->addSql('CREATE UNIQUE INDEX UNIQ_A7B0E9CC5E237E06 ON neos_party_domain_model_person (name)');
             $this->addSql('DROP INDEX idx_c60479e1a7cecf13 ON neos_party_domain_model_person');
             $this->addSql('CREATE INDEX IDX_A7B0E9CCA7CECF13 ON neos_party_domain_model_person (primaryelectronicaddress)');
             $this->addSql('ALTER TABLE neos_party_domain_model_person ADD CONSTRAINT neos_party_domain_model_person_ibfk_1 FOREIGN KEY (name) REFERENCES neos_party_domain_model_personname (persistence_object_identifier)');
             $this->addSql('ALTER TABLE neos_party_domain_model_person ADD CONSTRAINT neos_party_domain_model_person_ibfk_2 FOREIGN KEY (primaryelectronicaddress) REFERENCES neos_party_domain_model_electronicaddress (persistence_object_identifier)');
-            $this->addSql('ALTER TABLE neos_party_domain_model_person_electronicaddresses_join DROP FOREIGN KEY neos_party_domain_model_person_electronicaddresses_join_ibfk_1');
-            $this->addSql('ALTER TABLE neos_party_domain_model_person_electronicaddresses_join DROP FOREIGN KEY neos_party_domain_model_person_electronicaddresses_join_ibfk_2');
+
+            foreach ($this->sm->listTableForeignKeys('neos_party_domain_model_person_electronicaddresses_join') as $foreignKey) {
+                if (in_array('party_person', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+                    || in_array('party_electronicaddress', array_map('strtolower', $foreignKey->getLocalColumns()), true)
+                ) {
+                    $this->addSql("ALTER TABLE neos_party_domain_model_person_electronicaddresses_join DROP FOREIGN KEY " . $foreignKey->getName());
+                }
+            }
             $this->addSql('DROP INDEX idx_be7d49f772aaaa2f ON neos_party_domain_model_person_electronicaddresses_join');
             $this->addSql('CREATE INDEX IDX_131A08DD72AAAA2F ON neos_party_domain_model_person_electronicaddresses_join (party_person)');
             $this->addSql('DROP INDEX idx_be7d49f7b06bd60d ON neos_party_domain_model_person_electronicaddresses_join');


### PR DESCRIPTION
**What I did**

Some old Flow migrations dropped foreign keys by their hardcoded auto-generated names (e.g. `..._ibfk_1`). These names are no longer reliable: on MariaDB 12+, renaming a table no longer renames its auto-generated foreign key/index names along with it, so the constraint names the migrations expect may not exist and the migrations fail.

Instead of relying on hardcoded constraint names, the affected migrations now look up the actual foreign keys on the table via the schema manager and drop the one defined on the relevant column. This works regardless of what the constraint is actually named, making the migrations compatible with MySQL, MariaDB < 12 and MariaDB ≥ 12 alike.

**Why the CI change**

Until now this breakage went unnoticed because the pipeline never executed the Doctrine migrations. The build workflow now runs `./flow doctrine:migrate` before the functional tests, so the full migration chain is verified on every build.